### PR TITLE
Handle properly URLs with a host with unicode characters and missing scheme

### DIFF
--- a/core/src/main/java/kg/net/bazi/gsb4j/url/Canonicalization.java
+++ b/core/src/main/java/kg/net/bazi/gsb4j/url/Canonicalization.java
@@ -116,11 +116,11 @@ public class Canonicalization {
         }
 
         // convert host part to ASCII Punycode if needed
-        boolean isAscii = CharMatcher.ascii().matchesAllOf(url);
+        boolean isAscii = CharMatcher.ascii().matchesAllOf(str);
         if (!isAscii) {
-            URL tmp = new URL(url);
+            URL tmp = new URL(str);
             String hostPunyCode = IDN.toASCII(tmp.getHost());
-            str = url.replace(tmp.getHost(), hostPunyCode);
+            str = str.replace(tmp.getHost(), hostPunyCode);
         }
 
         // remove white space chars

--- a/core/src/test/java/kg/net/bazi/gsb4j/url/CanonicalizationTest.java
+++ b/core/src/test/java/kg/net/bazi/gsb4j/url/CanonicalizationTest.java
@@ -90,7 +90,7 @@ public class CanonicalizationTest {
         Assert.assertEquals("http://host.com/ab%23cd", canon.canonicalize("http://host.com/ab%23cd"));
         Assert.assertEquals("http://host.com/twoslashes?more//slashes", canon.canonicalize(
             "http://host.com//twoslashes?more//slashes"));
-        Assert.assertEquals("http://unicodehost.com/", canon.canonicalize("uñicodehost.com"));
+        Assert.assertEquals("http://xn--uicodehost-t9a.com/", canon.canonicalize("uñicodehost.com"));
     }
 
 }

--- a/core/src/test/java/kg/net/bazi/gsb4j/url/CanonicalizationTest.java
+++ b/core/src/test/java/kg/net/bazi/gsb4j/url/CanonicalizationTest.java
@@ -90,6 +90,7 @@ public class CanonicalizationTest {
         Assert.assertEquals("http://host.com/ab%23cd", canon.canonicalize("http://host.com/ab%23cd"));
         Assert.assertEquals("http://host.com/twoslashes?more//slashes", canon.canonicalize(
             "http://host.com//twoslashes?more//slashes"));
+        Assert.assertEquals("http://unicodehost.com/", canon.canonicalize("uñicodehost.com"));
     }
 
 }


### PR DESCRIPTION
Due to a bug it would cause an exception when trying to canonicalize.