### PR TITLE
Fix race condition in ThreatListDescriptorsCache

### DIFF
--- a/core/src/main/java/kg/net/bazi/gsb4j/cache/ThreatListDescriptorsCache.java
+++ b/core/src/main/java/kg/net/bazi/gsb4j/cache/ThreatListDescriptorsCache.java
@@ -56,7 +56,7 @@ public class ThreatListDescriptorsCache {
         readLock.lock();
         try {
             if (!cache.isEmpty()) {
-                return Collections.unmodifiableCollection(cache);
+                return Collections.unmodifiableCollection(new HashSet<>(cache));
             }
         } finally {
             readLock.unlock();
@@ -78,10 +78,10 @@ public class ThreatListDescriptorsCache {
         try {
             cache.clear();
             cache.addAll(ls);
+            return Collections.unmodifiableCollection(new HashSet<>(cache));
         } finally {
             writeLock.unlock();
         }
-        return Collections.unmodifiableCollection(cache);
     }
 
 }


### PR DESCRIPTION
`Collections.unmodifiableCollection` actually returns an immutable *view* of the collection, not a copy of the collection. This means that although the cache appears to be protected with a lock, the lock doesn't actually work because the returned collection can still be modified after the lock is released.

I've fixed this by creating a copy of the cache before passing it to `Collections.unmodifiableCollection`.

There's also another bug where in `getRefreshed`, `Collections.unmodifiableCollection` is called after the lock is released (also rendering the lock useless). I've fixed this as well just by moving the return statement.

We actually discovered these race conditions in our tests, here's the exception, showing what happens when we triggered the above race conditions:
```
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1445)
        at java.util.HashMap$KeyIterator.next(HashMap.java:1469)
        at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1044)
        at kg.net.bazi.gsb4j.api.UpdateApi.presentInThreatLists(UpdateApi.java:175)
        at kg.net.bazi.gsb4j.api.UpdateApi.findHashPrefixCollisions(UpdateApi.java:160)
        at kg.net.bazi.gsb4j.api.UpdateApi.check(UpdateApi.java:85)
```

P.S. Thank you so much for creating this library, I was so relieved when I found out someone had already written the URL canonicalization code for the GSB API!